### PR TITLE
Git Config to Zip eol CRLF for Source and ignore .Cache BAK LNK + MAP and OBJ folders

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,25 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Declare files that will always have CRLF line endings on checkout.
+*.sln text eol=crlf
+*.cwproj text eol=crlf
+*.clw text eol=crlf
+*.inc text eol=crlf
+*.[Ii][Nn][Cc] text eol=crlf
+*.trn text eol=crlf
+*.exp text eol=crlf
+*.[Ii][Nn][Ii] text eol=crlf
+*.txa text eol=crlf
+*.[Tt][Xx][Aa] text eol=crlf
+
+
+# Denote all files that are truly binary and should not be modified.
+*.bmp binary
+*.[Bb][Mm][Pp] binary
+*.ico binary
+*.[Ii][Cc][Oo] binary
+*.app binary
+*.[Aa][Pp][Pp] binary
+*.dct binary
+*.[Dd][Cc][Tt] binary

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,10 @@
 *.EXP
 *.INI
 *.cwproj.FileList.xml
+map/
+obj/
+*.cache
+*.bak
+*.[Bb][Aa][Kk]
+*.lnk
+*.[Ll][Nn][Kk]


### PR DESCRIPTION
.GitAttributes add eol=CRLF to some source files so zip is right Ignore .Cache, .BAK, .LNK (shortcuts) and folders MAP and OBJ